### PR TITLE
Output param should not be optional for replaceOutputWith()

### DIFF
--- a/lib/writer.php
+++ b/lib/writer.php
@@ -22,7 +22,7 @@ abstract class cache_warmup_writer
      *
      * @param string $output
      */
-    public static function replaceOutputWith($output = '')
+    public static function replaceOutputWith($output)
     {
         rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) use ($output) {
             $ep->setSubject($output);


### PR DESCRIPTION
Man darf von außen einen leerstring reingeben aber generell sollte man bei diesem methodennamen erwarten dass man was reingeben muss