### PR TITLE
Remove un-used default param value

### DIFF
--- a/lib/selector.php
+++ b/lib/selector.php
@@ -264,7 +264,7 @@ abstract class cache_warmup_selector
      * @param int $chunkSize
      * @return array
      */
-    private static function chunk(array $items, $chunkSize = 3)
+    private static function chunk(array $items, $chunkSize)
     {
         return array_chunk($items, $chunkSize);
     }


### PR DESCRIPTION
Die methode wird nie ohne den 2. param aufgerufen, daher ist der default ungenutzt