### PR TITLE
Feature: Cachefiles pro Request deutlich erhöht

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -14,10 +14,10 @@ $this->setConfig('chunkSizePages', 42); // magic redaxo number
 if (rex::isBackend() && rex::getUser()) {
 
     if (rex_be_controller::getCurrentPagePart(2) == 'warmup') {
-        rex_view::addJsFile($this->getAssetsUrl('js/handlebars.min.js?v='.$this->getVersion()));
-        rex_view::addJsFile($this->getAssetsUrl('js/timer.jquery.min.js?v='.$this->getVersion()));
+        rex_view::addJsFile($this->getAssetsUrl('js/handlebars.min.js?v=' . $this->getVersion()));
+        rex_view::addJsFile($this->getAssetsUrl('js/timer.jquery.min.js?v=' . $this->getVersion()));
     }
 
-    rex_view::addCssFile($this->getAssetsUrl('css/cache-warmup.css?v='.$this->getVersion()));
-    rex_view::addJsFile($this->getAssetsUrl('js/cache-warmup.js?v='.$this->getVersion()));
+    rex_view::addCssFile($this->getAssetsUrl('css/cache-warmup.css?v=' . $this->getVersion()));
+    rex_view::addJsFile($this->getAssetsUrl('js/cache-warmup.js?v=' . $this->getVersion()));
 }


### PR DESCRIPTION
Bisher hatten wir die Anzahl der Cachefiles, die pro Request generiert werden, sehr niedrig angesetzt: 4 Bilder und 42 Seiten. Mit diesem Update wird die Anzahl der Cachefiles pro Request deutlich erhöht, indem die Skriptlaufzeit des Servers (`max_execution_time`) beachtet wird. Bei nur sehr geringer Skriptlaufzeit (etwa bei einem einfachen Shared-Hosting) arbeiten wir nun immerhin mit 10 Bildern und 100 Seiten pro Request. Bei längeren Skriptlaufzeiten erhöhen sich die Werte auf bis zu 50 Bilder und 1000 Seiten. 🎉

Als Ergebnis sollte Cache-Warmup deutlich schnell laufen als bisher, weil es weniger Requests absetzen muss.

fixes #58