### PR TITLE
EP um Bilder hinzuzufügen

### DIFF
--- a/lib/selector.php
+++ b/lib/selector.php
@@ -134,6 +134,8 @@ abstract class cache_warmup_selector
 
             /* prepare and return ------------------------------------------------- */
 
+            $images = rex_extension::registerPoint(new rex_extension_point('CACHE_WARMUP_IMAGES_SELECTED', $images));
+            
             // filter images
             $images = self::filterImages($images);
 

--- a/lib/selector.php
+++ b/lib/selector.php
@@ -134,6 +134,7 @@ abstract class cache_warmup_selector
 
             /* prepare and return ------------------------------------------------- */
 
+            // create extension point (EP) for developers to extend selected images
             $images = rex_extension::registerPoint(new rex_extension_point('CACHE_WARMUP_IMAGES', $images));
             
             // filter images

--- a/lib/selector.php
+++ b/lib/selector.php
@@ -134,7 +134,7 @@ abstract class cache_warmup_selector
 
             /* prepare and return ------------------------------------------------- */
 
-            $images = rex_extension::registerPoint(new rex_extension_point('CACHE_WARMUP_IMAGES_SELECTED', $images));
+            $images = rex_extension::registerPoint(new rex_extension_point('CACHE_WARMUP_IMAGES', $images));
             
             // filter images
             $images = self::filterImages($images);


### PR DESCRIPTION
In der selector.php werden die Bilder zum Warmup anhand der Redaxo Widgets gesammelt. Bilder, die nicht über diese Widgets geladen werden, bleiben allerdings aussen vor. Über den EP können diese Bilder noch hinzugefügt werden.