### PR TITLE
use new `rex_media_manager::create()` (v2.3.0)

### DIFF
--- a/lib/generator_images.php
+++ b/lib/generator_images.php
@@ -41,7 +41,12 @@ class cache_warmup_generator_images extends cache_warmup_generator
                 foreach ($mediaTypes as $type) {
                     $media = rex_media::get($image);
                     if ($media instanceof rex_media && $media->isImage()) {
-                        cache_warmup_media_manager::init($image, $type);
+                        if (method_exists('rex_media_manager', 'create')) {
+                            rex_media_manager::create($type, $image);
+                        } else {
+                            // use fallback for media_manager < 2.3.0
+                            cache_warmup_media_manager::init($image, $type);
+                        }
                     }
                 }
             }

--- a/lib/media_manager.php
+++ b/lib/media_manager.php
@@ -2,10 +2,14 @@
 
 /**
  * Class cache_warmup_media_manager
+ * @deprecated since media_manager 2.3.0
  */
 class cache_warmup_media_manager extends rex_media_manager
 {
 
+    /**
+     * @deprecated since media_manager 2.3.0, use `rex_media_manager::create()` instead
+     */
     public static function init()
     {
         list($file, $type) = func_get_args();
@@ -25,6 +29,9 @@ class cache_warmup_media_manager extends rex_media_manager
         }
     }
 
+    /**
+     * @deprecated since media_manager 2.3.0
+     */
     public function sendMedia()
     {
         $headerCacheFilename = $this->getHeaderCacheFilename();


### PR DESCRIPTION
Der Media-Manager 2.3.0 hat nun eine separate Methode, um Cachefiles von Bildern mit allen Bildeffekten zu generieren. Diese können wir für Cache-Warmup nutzen und benötigen dadurch keine eigenen Methoden mehr. Sie werden jedoch als Fallback für MM <2.3.0 behalten.