### PR TITLE
add js/css assets only on warmup pages

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -46,8 +46,8 @@ rex_extension::register('PACKAGES_INCLUDED', function (rex_extension_point $ep) 
     }
 }, rex_extension::EARLY);
 
-// inject addon ressources
-if (rex::isBackend() && rex::getUser() && rex_be_controller::getCurrentPagePart(1) == 'cache_warmup') {
+// inject addon ressources, for both cache_warmup/generator and system/cache_warmup
+if (rex::isBackend() && rex::getUser() && strpos(rex_be_controller::getCurrentPage(), 'cache_warmup') !== false) {
 
     if (rex_be_controller::getCurrentPagePart(2) == 'warmup') {
         rex_view::addJsFile($this->getAssetsUrl('js/handlebars.min.js'));

--- a/boot.php
+++ b/boot.php
@@ -46,7 +46,7 @@ rex_extension::register('PACKAGES_INCLUDED', function (rex_extension_point $ep) 
     }
 }, rex_extension::EARLY);
 
-// inject addon ressources, for both cache_warmup/generator and system/cache_warmup
+// inject addon ressources, for both cache_warmup/warmup and system/cache_warmup
 if (rex::isBackend() && rex::getUser() && strpos(rex_be_controller::getCurrentPage(), 'cache_warmup') !== false) {
 
     if (rex_be_controller::getCurrentPagePart(2) == 'warmup') {

--- a/boot.php
+++ b/boot.php
@@ -47,7 +47,7 @@ rex_extension::register('PACKAGES_INCLUDED', function (rex_extension_point $ep) 
 }, rex_extension::EARLY);
 
 // inject addon ressources
-if (rex::isBackend() && rex::getUser()) {
+if (rex::isBackend() && rex::getUser() && rex_be_controller::getCurrentPagePart(1) == 'cache_warmup') {
 
     if (rex_be_controller::getCurrentPagePart(2) == 'warmup') {
         rex_view::addJsFile($this->getAssetsUrl('js/handlebars.min.js'));


### PR DESCRIPTION
without this change, the `warmup.(css|js)` is included in all backend pages, so e.g. even on structure/ or similar.

while working at it I am wondering whether the styles are required at all. @schuer are you sure this files (and their contents) are still used?

Relates to https://github.com/redaxo/redaxo/issues/1406