### PR TITLE
EPs zum Filtern der zu generierenden Objekte

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: cache_warmup
-version: '3.2.0'
+version: '3.3.0-dev'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/cache_warmup
 


### PR DESCRIPTION
Ich habe wie vor einiger Zeit besprochen mehrere EPs eingebaut, um eingreifen zu können, welche Cachefiles generiert werden sollen. 

Die EPs greifen bereits nach der Selektion durch das AddOn ein, und nicht erst kurz vorm Generieren der Cachefiles. Das hat den Vorteil, dass das AddOn bereits weiß, wie viele Files zu generieren sind, es kann also vorab durchzählen. Bedeutet, wenn man beispielsweise Medienpool-Kategorien oder Medientypen ausschließt, wird auch der Zähler am Fortschrittsbalken kleiner.

Den EP `CACHE_WARMUP_PAGES` halte ich für kaum sinnvoll, er ist aber natürlich der Vollständigkeit halber mit drin. Und auch `CACHE_WARMUP_MEDIATYPES` ist vermutlich nicht allzu praktikabel, zumindest erschließt sich mir kein konkreter Anwendungsfall.

Überaus praktisch ist allerdings `CACHE_WARMUP_GENERATE_IMAGE`, der hier dringend gewünscht wurde, um zu steuern, welcher Bilder mit welchen Mediatypes generiert werden. Damit kann man beispielsweise komplette Medienpool-Kategorien auslassen oder auch Medientypen, die nicht generiert werden sollen.

Für Pages gibt es einen gleichwertigen EP, aber der ist nun wieder weniger wichtig, weil Pages ratzfatz generiert werden und zudem der Online-Status beachtet wird, so dass typische Hilfsartikel gar nicht erst selektiert werden.

Bin gespannt auf euer Feedback und ob das so auf eure Anforderungen hin taugt. Speziell @tbaddade und @alexplusde hatten sich was in diese Richtung gewünscht.

Falls gemerged wird:
closes #86
closes #88 