### PR TITLE
Einstellungsseite + Debugmodus hinzugefügt

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -5,16 +5,22 @@ if (rex_be_controller::getCurrentPage() == 'system/cache_warmup') {
     // min: min number of items to generate per request
     // max: max number of items to generate per request
     // ratio: multiplies with execution time to define number of items to generate per request
-    $chunksConfig = array(
-        'chunkSizeImages' => array('min' => 10, 'max' => 50, 'ratio' => 0.4),
-        'chunkSizePages' => array('min' => 100, 'max' => 1000, 'ratio' => 6)
-    );
-
+    if($this->getConfig('debug') != 1) {   
+        $chunksConfig = array(
+            'chunkSizeImages' => array('min' => $this->getConfig('image_min'), 'max' => $this->getConfig('image_max'), 'ratio' => $this->getConfig('image_ratio')),
+            'chunkSizePages' => array('min' => $this->getConfig('article_min'), 'max' => $this->getConfig('article_max'), 'ratio' => $this->getConfig('article_ratio'))
+        );
+    } else {
+        $chunksConfig = array(
+            'chunkSizeImages' => array('min' => 1, 'max' => 1, 'ratio' => 1),
+            'chunkSizePages' => array('min' => 1, 'max' => 1, 'ratio' => 1)
+        );
+    }
     // get `max_execution_time`
     // if it’s false, set to a low value
     $executionTime = ini_get('max_execution_time');
     if ($executionTime === false) {
-        $executionTime = 30;
+        $executionTime = $this->getConfig('max_execution_time');
     }
 
     // define number of items to generate per single request based on `max_execution_time`

--- a/install.php
+++ b/install.php
@@ -1,0 +1,17 @@
+<?php
+
+/** @var rex_addon $this */
+
+if (!$this->hasConfig()) {
+    $this->setConfig([
+        'chunkSizeImages' => false,
+        'chunkSizePages' => false,
+        'image_min' => 10,
+        'image_max' => 50,
+        'image_ratio' => 0.4,
+        'article_min' => 100,
+        'article_max' => 1000,
+        'article_ratio' => 6,
+        'max_execution_time' => 30
+    ]);
+}

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -23,3 +23,32 @@ cache_warmup_error_link      = Link zur Fehlerseite
 
 cache_warmup_nothing_title   = Keine Inhalte?
 cache_warmup_nothing_text    = <p>Tut mir leid, aber es gibt nichts zum Cachen. Keine Bilder und keine Texte. Entweder ist REDAXO leer, oder die notwendigen Addons (<code>media_manager</code> für Bilder und <code>structure</code> für Inhalte) sind nicht installiert.</p>
+
+cache_warmup_settings_title       = Einstellungen
+
+cache_warmup_settings_debug_label       = Debug
+cache_warmup_settings_debug_notice      = wenn aktiviert, werden die Artikel und Bilder einzeln durchlaufen sowie die nachfolgenden Einstellungen ignoriert.
+cache_warmup_settings_debug_option_on   = ja
+cache_warmup_settings_debug_option_off  = nein
+
+cache_warmup_settings_max_execution_time_label     = Maximale Skript-Laufzeit
+cache_warmup_settings_max_execution_time_notice    = Wenn <code>ini_get('max_execution_time')</code> nicht verfügbar, dann diesen Wert benutzen. Standard: <code>30</code> Sekunden.
+cache_warmup_settings_validate_default  = Bitte geben Sie eine Zahl ein.
+
+cache_warmup_settings_image_min_label     = Bilder min
+cache_warmup_settings_image_min_notice    = Anzahl der Bilder, die mindestens mit einem Aufruf generiert werden. Standard: <code>10</code>
+
+cache_warmup_settings_image_max_label     = Bilder max
+cache_warmup_settings_image_max_notice    = Anzahl der Bilder, die maximal mit einem Aufruf generiert werden. Standard: <code>50</code>
+
+cache_warmup_settings_image_ratio_label     = Bilder (Verhältnis)
+cache_warmup_settings_image_ratio_notice    = Menge der Bilder pro Aufruf im Verhältnis zur maximalen Skript-Laufzeit. Standard: <code>0.4</code>
+
+cache_warmup_settings_article_min_label     = Artikel min
+cache_warmup_settings_article_min_notice    = Anzahl der Artikel, die mindestens mit einem Aufruf generiert werden. Standard: <code>100</code>
+
+cache_warmup_settings_article_max_label     = Artikel max
+cache_warmup_settings_article_max_notice    = Anzahl der Artikel, die maximal mit einem Aufruf generiert werden. Standard: <code>1000</code>
+
+cache_warmup_settings_article_ratio_label     = Artikel (Verhältnis)
+cache_warmup_settings_article_ratio_notice    = Anzahl der Artikel, die mindestens mit einem Aufruf generiert werden. Standard: <code>6</code>

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: cache_warmup
-version: '3.4.0'
+version: '3.5'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/cache_warmup
 
@@ -22,9 +22,10 @@ pages:
     system/cache_warmup:
         title: translate:title
         perm: admin
+        pjax: false
 
 requires:
-    redaxo: '^5.1'
+    redaxo: '^5.6'
     php: '>=5.5'
 
 # define conflicts: prevents packages from update to avoid breaking changes

--- a/pages/system.cache_warmup.php
+++ b/pages/system.cache_warmup.php
@@ -10,3 +10,67 @@ $fragment = new rex_fragment();
 $fragment->setVar('title', rex_i18n::rawMsg('cache_warmup_title'));
 $fragment->setVar('body', $content, false);
 echo $fragment->parse('core/page/section.php');
+
+
+if (rex_post('btn_save', 'string') != '') {
+    $this->setConfig(rex_post('settings', [
+        ['cache_warmup_debug', 'string'],
+        ['dsgvo_consent_css', 'string']
+    ]));
+
+    $message = $this->i18n('cache_warmup_settings_save_success');
+}
+
+
+/* Einstellungen */
+
+$form = rex_config_form::factory( $this->name );
+
+$field = $form->addTextField("max_execution_time");
+$field->setLabel($this->i18n("cache_warmup_settings_max_execution_time_label"));
+$field->setNotice($this->i18n("cache_warmup_settings_max_execution_time_notice"));
+$field->getValidator()->add("type", $this->i18n("cache_warmup_settings_validate_default"), "int");
+
+$field = $form->addSelectField('debug',NULL, ['class'=>'form-control selectpicker']);
+$field->setLabel($this->i18n("cache_warmup_settings_debug_label"));
+$select = $field->getSelect();
+$select->setSize(2);
+$select->addOption($this->i18n("cache_warmup_settings_debug_option_off"), 0);
+$select->addOption($this->i18n("cache_warmup_settings_debug_option_on"), 1);
+$field->setNotice($this->i18n("cache_warmup_settings_debug_notice"));
+
+$field = $form->addTextField("image_ratio");
+$field->setLabel($this->i18n("cache_warmup_settings_image_ratio_label"));
+$field->setNotice($this->i18n("cache_warmup_settings_image_ratio_notice"));
+$field->getValidator()->add("type", $this->i18n("cache_warmup_settings_validate_default"), "float");
+
+$field = $form->addTextField("image_min");
+$field->setLabel($this->i18n("cache_warmup_settings_image_min_label"));
+$field->setNotice($this->i18n("cache_warmup_settings_image_min_notice"));
+$field->getValidator()->add("type", $this->i18n("cache_warmup_settings_validate_default"), "int");
+
+$field = $form->addTextField("image_max");
+$field->setLabel($this->i18n("cache_warmup_settings_image_max_label"));
+$field->setNotice($this->i18n("cache_warmup_settings_image_max_notice"));
+$field->getValidator()->add("type", $this->i18n("cache_warmup_settings_validate_default"), "int");
+
+$field = $form->addTextField("article_ratio");
+$field->setLabel($this->i18n("cache_warmup_settings_article_ratio_label"));
+$field->setNotice($this->i18n("cache_warmup_settings_article_ratio_notice"));
+$field->getValidator()->add("type", $this->i18n("cache_warmup_settings_validate_default"), "float");
+
+$field = $form->addTextField("article_min");
+$field->setLabel($this->i18n("cache_warmup_settings_article_min_label"));
+$field->setNotice($this->i18n("cache_warmup_settings_article_min_notice"));
+$field->getValidator()->add("type", $this->i18n("cache_warmup_settings_validate_default"), "int");
+
+$field = $form->addTextField("article_max");
+$field->setLabel($this->i18n("cache_warmup_settings_article_max_label"));
+$field->setNotice($this->i18n("cache_warmup_settings_article_max_notice"));
+$field->getValidator()->add("type", $this->i18n("cache_warmup_settings_validate_default"), "int");
+
+$fragment = new rex_fragment();
+$fragment->setVar('class', 'edit', false);
+$fragment->setVar('title', $this->i18n("cache_warmup_settings_title"), false);
+$fragment->setVar('body', $form->get(), false);
+echo $fragment->parse('core/page/section.php');

--- a/update.php
+++ b/update.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @var rex_addon $this
+ */
+
+if (rex_string::versionCompare($this->getVersion(), '3.4.1', '<')) {
+    $this->setConfig([
+        'image_min' => 10,
+        'image_max' => 50,
+        'image_ratio' => 0.4,
+        'article_min' => 100,
+        'article_max' => 1000,
+        'article_ratio' => 6,
+        'max_execution_time' => 30
+    ]);
+}


### PR DESCRIPTION
Parameter aus der boot.php können jetzt direkt festgelegt werden.
PJAX deaktiviert, da dies das Warmup-Popup in einem neuen Tab öffnen lässt, wenn zuvor die Einstellungen gespeichert wurden.