### PR TITLE
Update system.cache_warmup.start.php

### DIFF
--- a/pages/system.cache_warmup.start.php
+++ b/pages/system.cache_warmup.start.php
@@ -3,7 +3,7 @@
 $content = '';
 
 $content .= '<p>' . rex_i18n::rawMsg('cache_warmup_description') . '</p>';
-$content .= '<p><a class="btn btn-primary cache-warmup__button-start" href="' . rex_url::backendPage('cache_warmup/warmup') . '" target="CacheWarmupWindow">' . rex_i18n::rawMsg('cache_warmup_button_start') . ' <i class="fa fa-external-link" aria-hidden="true"></i></a></p>';
+$content .= '<p><a class="btn btn-primary cache-warmup__button-start" href="' . rex_url::backendPage('cache_warmup/warmup') . '" target="_blank">' . rex_i18n::rawMsg('cache_warmup_button_start') . ' <i class="fa fa-external-link" aria-hidden="true"></i></a></p>';
 
 $fragment = new rex_fragment();
 $fragment->setVar('title', rex_i18n::rawMsg('cache_warmup_title'));


### PR DESCRIPTION
Aktuell wird beim Klick auf den "Fehler anzeigen"-Link der Whoops in dem kleinen Poup gezeigt.

![image](https://user-images.githubusercontent.com/3855487/183299694-833034ad-4b37-449e-9d78-92dc102dae56.png)

Dieser PR korrigiert das.